### PR TITLE
Fixed infinite loop of refreshing inventory.

### DIFF
--- a/src/pages/Inventory.jsx
+++ b/src/pages/Inventory.jsx
@@ -146,7 +146,7 @@ export function Inventory() {
 
   useEffect(() => {
     auth.isAdmin ? getAllBooks() : getAllNonReservedByUserBooks();
-  }, );
+  }, []);
 
   return (
     <div>


### PR DESCRIPTION
 Reserved books should now disappear from the overview (or perhaps only with the additional back-end changes.